### PR TITLE
Fix a broken link to routing tutorial

### DIFF
--- a/docs/index.fsx
+++ b/docs/index.fsx
@@ -41,7 +41,7 @@ Program.mkProgram init update view
 |> Program.run
 
 (**
-For more information see the [routing tutorial](routing.html).
+For more information see the [routing tutorial](tutorials/routing.html).
 
 ### Navigation
 Manipulate the browser's navigation and history.


### PR DESCRIPTION
While looking for docs on routing, I noticed that the "routing tutorial" link was broken on [this page](https://elmish.github.io/browser/).

I don't speak Nacara but I believe this PR should [fix the link](https://elmish.github.io/browser/tutorials/routing.html).